### PR TITLE
Add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 .DS_Store
 .vs/
 *.zip
+.vscode

--- a/arc_welder_cli/CMakeLists.txt
+++ b/arc_welder_cli/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.6)
+project(arc_welder)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+
+file(GLOB src
+    "../octoprint_arc_welder/data/lib/c/arc_welder/*.cpp"
+    "../octoprint_arc_welder/data/lib/c/arc_welder/*.h"
+    "../octoprint_arc_welder/data/lib/c/gcode_processor_lib/*.cpp"
+    "../octoprint_arc_welder/data/lib/c/gcode_processor_lib/*.h"
+    "main.cpp"
+    )
+
+add_executable(arc_welder ${src})
+
+# target_link_libraries(arc_welder )
+target_include_directories(arc_welder PUBLIC ../octoprint_arc_welder/data/lib/c/gcode_processor_lib ../octoprint_arc_welder/data/lib/c/arc_welder)

--- a/arc_welder_cli/main.cpp
+++ b/arc_welder_cli/main.cpp
@@ -1,0 +1,94 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <stdlib.h>
+
+#include "arc_welder.h"
+#include "logger.h"
+
+using namespace std;
+
+bool arc_progress_callback(arc_welder_progress progress, logger* p_logger, int logger_type) {
+    cout << progress.str() << "\n";
+    return true;
+}
+
+int main(int argc, char* argv[]) {
+    std::vector<string> args;
+	cerr << "PyArcWelder V0.1.0rc1.dev2 imported - Copyright (C) 2019  Brad Hochgesang...\n";
+
+    if (argc > 1) {
+        args.assign(argv + 1, argv + argc);
+    }
+
+    if (args.size() < 2) {
+        cerr << "Usage: arc_welder [options] <infile> <outfile>\n";
+        cerr << "Available options:\n";
+        cerr << "-r <mm>        --resolution <mm>   This setting controls how much play *Arc Welder* has in converting GCode points into arcs.  If the arc deviates from the original points by + or - 1/2 of the resolution, the points will **not** be converted.  The default setting is 0.05 which means the arcs may not deviate by more than +- 0.025mm (that's a **really** tiny deviation).  Increasing the resolution will result in more arcs being converted but will make the tool paths less accurate.  Decreasing the resolution will result in fewer arcs but more accurate tool paths.  I don't recommend going above 0.1MM.  Higher values than that may result in print failure.\n\n";
+        cerr << "-i <mm>        --radius <mm>       This is a safety feature to prevent unusually large arcs from being generated.  Internally, *Arc Welder* uses a constant to prevent an arc with a very large radius from being generated where the path is essentially (but not exactly) a straight line.  If it is not perfectly straight and if my constant isn't conservative enough, an extremely large arc could be created that may have the wrong direction of rotation.  The default setting is **1000000 mm** or **1KM**.\n\n";
+        cerr << "-g                                 This flag disables use of G90/G91.  *Arc Welder* will use this setting to determine if the G90/G91 command influences your extruder's axis mode.  In general, Marlin 2.0 and forks SHOULD NOT have this flag.  Many forks of Marlin 1.x SHOULD have this flag, like the Prusa MK2 and MK3.\n\n";
+        return 1;
+    }
+
+    double resolution_mm = 0.05;
+    double max_radius_mm = 1000.0*1000.0;
+    bool g90_g91_influences_extruder = true;
+    for (size_t i = 0; i < args.size() - 2; ++i) {
+        string arg = args[i];
+        if (arg == "-r" || arg == "--resolution") {
+            if (i >= args.size() - 3) {
+                cerr << "Missing mm for resolution, run `arc_welder` to see help.\n";
+                return 1;
+            }
+            resolution_mm = strtod(args[i + 1].c_str(), NULL);
+            if (resolution_mm <= 0.0 || resolution_mm > 1000*1000) {
+                cerr << "Invalid mm for resolution, run `arc_welder` to see help.\n";
+                return 1;
+            }
+        } else if (arg == "-i" || arg == "--radius") {
+            if (i >= args.size() - 3) {
+                cerr << "Missing mm for radius, run `arc_welder` to see help.\n";
+                return 1;
+            }
+            max_radius_mm = strtod(args[i + 1].c_str(), NULL);
+            if (max_radius_mm <= 0.0 || max_radius_mm > 1000*1000*1000) {
+                cerr << "Invalid mm for radius, run `arc_welder` to see help.\n";
+                return 1;
+            }
+        } else if (arg == "-g") {
+            g90_g91_influences_extruder = false;
+        } else {
+            cerr << "Invalid flag: '" << arg << "', run `arc_welder` to see help.\n";
+            return 1;
+        }
+    }
+    std::vector<string> logger_names;
+	logger_names.push_back("arc_welder.gcode_conversion");
+	std::vector<int> logger_levels;
+	logger_levels.push_back(log_levels::DEBUG);
+	logger logs(logger_names, logger_levels);
+    logs.set_log_level(log_levels::INFO);
+    logs.set_streams(&cerr, &cerr);
+    // std::string source_path, std::string target_path, logger* log, double resolution_mm, double max_radius, bool g90_g91_influences_extruder, int buffer_size, progress_callback callback = NULL
+    arc_welder welder(args[0], args[1], &logs, resolution_mm, max_radius_mm, g90_g91_influences_extruder, 50, &arc_progress_callback);
+    auto results = welder.process();
+    if (results.success) {
+        cout << results.progress.str() << "\n";
+        if (results.message.length() > 0) {
+            cerr << "Finished successfully with message: " << results.message << "\n";
+        } else {
+            cerr << "Finished successfully\n";
+        }
+        return 0;
+    } else if (results.cancelled) {
+        if (results.message.length() > 0) {
+            cerr << "Cancelled with message: " << results.message << "\n";
+        } else {
+            cerr << "Cancelled\n";
+        }
+        return 1;
+    } else {
+        cerr << "Weird state, neither successful nor cancelled\n";
+        return 1;
+    }
+}

--- a/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.cpp
+++ b/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.cpp
@@ -23,6 +23,7 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #endif
 #include "logger.h"
+
 logger::logger(std::vector<std::string> names, std::vector<int> levels) {
 	// set to true by default, but can be changed by inheritance to support mandatory innitialization (for python or other integrations)
 	loggers_created_ = true;
@@ -36,12 +37,19 @@ logger::logger(std::vector<std::string> names, std::vector<int> levels) {
 		logger_levels_[index] = levels[index];
 	}
 	
-	set_log_level_by_value(NOSET);
+	set_log_level(NOSET);
+	this->stdout = &std::cout;
+	this->stderr = &std::cerr;
 }
 
 logger::~logger() {
 	delete[] logger_names_;
 	delete[] logger_levels_;
+}
+
+void logger::set_streams(std::ostream* stdout, std::ostream* stderr) {
+	this->stdout = stdout;
+	this->stderr = stderr;
 }
 
 void logger::set_log_level_by_value(const int logger_type, const int level_value)
@@ -131,12 +139,12 @@ void logger::log(const int logger_type, const int log_level, const std::string& 
 	create_log_message(logger_type, log_level, message, output);
 
 	// write the log
-	if (is_exception)
-		std::cerr << output << std::endl;
-	else
-		std::cout << output << std::endl;
-	std::cout.flush();
-	
+	if (is_exception) {
+		*this->stderr << output << std::endl;
+	} else {
+		*this->stdout << output << std::endl;
+		this->stdout->flush();
+	}
 }
 
 void logger::get_timestamp(std::string &timestamp)

--- a/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.cpp
+++ b/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.cpp
@@ -141,6 +141,7 @@ void logger::log(const int logger_type, const int log_level, const std::string& 
 	// write the log
 	if (is_exception) {
 		*this->stderr << output << std::endl;
+		this->stderr->flush();
 	} else {
 		*this->stdout << output << std::endl;
 		this->stdout->flush();

--- a/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.h
+++ b/octoprint_arc_welder/data/lib/c/gcode_processor_lib/logger.h
@@ -55,15 +55,18 @@ public:
 	static int get_log_level_value(const int log_level);
 	static int get_log_level_for_value(int log_level_value);
 	virtual bool is_log_level_enabled(const int logger_type, const int log_level);
+
+	void set_streams(std::ostream* stdout, std::ostream* stderr);
 protected:
 	virtual void create_log_message(const int logger_type, const int log_level, const std::string& message, std::string& output);
 	
 	bool loggers_created_;
+	std::ostream* stdout;
+	std::ostream* stderr;
 private:
 	std::string* logger_names_;
 	int * logger_levels_;
 	int num_loggers_;
 	static void get_timestamp(std::string &timestamp);
-	
 };
 

--- a/octoprint_arc_welder/data/lib/c/py_arc_welder/py_arc_welder_extension.cpp
+++ b/octoprint_arc_welder/data/lib/c/py_arc_welder/py_arc_welder_extension.cpp
@@ -153,7 +153,7 @@ extern "C" void initPyArcWelder(void)
 	p_py_logger->initialize_loggers();
 	std::string message = "PyArcWelder V0.1.0rc1.dev2 imported - Copyright (C) 2019  Brad Hochgesang...";
 	p_py_logger->log(GCODE_CONVERSION, INFO, message);
-	p_py_logger->set_log_level_by_value(DEBUG);
+	p_py_logger->set_log_level(DEBUG);
 	std::cout << " Initialization Complete\r\n";
 
 #if PY_MAJOR_VERSION >= 3

--- a/octoprint_arc_welder/data/lib/c/py_arc_welder/py_logger.cpp
+++ b/octoprint_arc_welder/data/lib/c/py_arc_welder/py_logger.cpp
@@ -63,18 +63,18 @@ void py_logger::initialize_loggers()
 	PyObject* funcArgs = Py_BuildValue("(s,s,s)", "arc_welder", "arc_welder.", "octoprint_arc_welder.");
 	if (funcArgs == NULL)
 	{
-		std::cout << "Unable to create LoggingConfigurator arguments, exiting.\r\n";
+		*this->stdout << "Unable to create LoggingConfigurator arguments, exiting.\r\n";
 		PyErr_SetString(PyExc_ImportError, "Could not create LoggingConfigurator arguments.");
 		return;
 	}
 	
 	py_logging_configurator = PyObject_CallObject(py_logging_configurator_name, funcArgs);
-	std::cout << "Complete.\r\n";
+	*this->stdout << "Complete.\r\n";
 	Py_DECREF(funcArgs);
 	PyGILState_Release(gstate);
 	if (py_logging_configurator == NULL)
 	{
-		std::cout << "The LoggingConfigurator is null, exiting.\r\n";
+		*this->stdout << "The LoggingConfigurator is null, exiting.\r\n";
 		PyErr_SetString(PyExc_ImportError, "Could not create a new instance of LoggingConfigurator.");
 		return;
 	}
@@ -83,7 +83,7 @@ void py_logger::initialize_loggers()
 	py_arc_welder_gcode_conversion_logger = PyObject_CallMethod(py_logging_configurator, (char*)"get_logger", (char*)"s", "octoprint_arc_welder.gcode_conversion");
 	if (py_arc_welder_gcode_conversion_logger == NULL)
 	{
-		std::cout << "No child logger was created, exiting.\r\n";
+		*this->stdout << "No child logger was created, exiting.\r\n";
 		PyErr_SetString(PyExc_ImportError, "Could not create the arc_welder.gcode_parser child logger.");
 		return;
 	}
@@ -142,14 +142,14 @@ void py_logger::log(const int logger_type, const int log_level, const std::strin
 		current_log_level = gcode_conversion_log_level;
 		break;
 	default:
-		std::cout << "Logging.arc_welder_log - unknown logger_type.\r\n";
+		*this->stdout << "Logging.arc_welder_log - unknown logger_type.\r\n";
 		PyErr_SetString(PyExc_ValueError, "Logging.arc_welder_log - unknown logger_type.");
 		return;
 	}
 
 	if (!check_log_levels_real_time)
 	{
-		//std::cout << "Current Log Level: " << current_log_level << " requested:" << log_level;
+		//*this->stdout << "Current Log Level: " << current_log_level << " requested:" << log_level;
 		// For speed we are going to check the log levels here before attempting to send any logging info to Python.
 		if (current_log_level > log_level)
 		{
@@ -197,7 +197,7 @@ void py_logger::log(const int logger_type, const int log_level, const std::strin
 			pyFunctionName = py_critical_function_name;
 			break;
 		default:
-			std::cout << "An unknown log level of '" << log_level << " 'was supplied for the message: " << message.c_str() << "\r\n";
+			*this->stdout << "An unknown log level of '" << log_level << " 'was supplied for the message: " << message.c_str() << "\r\n";
 			PyErr_Format(PyExc_ValueError,
 				"An unknown log level was supplied for the message %s.", message.c_str());
 			return;
@@ -206,7 +206,7 @@ void py_logger::log(const int logger_type, const int log_level, const std::strin
 	PyObject* pyMessage = gcode_arc_converter::PyUnicode_SafeFromString(message);
 	if (pyMessage == NULL)
 	{
-		std::cout << "Unable to convert the log message '" << message.c_str() << "' to a PyString/Unicode message.\r\n";
+		*this->stdout << "Unable to convert the log message '" << message.c_str() << "' to a PyString/Unicode message.\r\n";
 		PyErr_Format(PyExc_ValueError,
 			"Unable to convert the log message '%s' to a PyString/Unicode message.", message.c_str());
 		return;
@@ -220,14 +220,14 @@ void py_logger::log(const int logger_type, const int log_level, const std::strin
 	{
 		if (!PyErr_Occurred())
 		{
-			std::cout << "Logging.arc_welder_log - null was returned from the specified logger.\r\n";
+			*this->stdout << "Logging.arc_welder_log - null was returned from the specified logger.\r\n";
 			PyErr_SetString(PyExc_ValueError, "Logging.arc_welder_log - null was returned from the specified logger.");
 			return;
 		}
 		else
 		{
-			std::cout << "Logging.arc_welder_log - null was returned from the specified logger and an error was detected.\r\n";
-			std::cout << "\tLog Level: " << log_level <<", Logger Type: " << logger_type << ", Message: " << message.c_str() << "\r\n";
+			*this->stdout << "Logging.arc_welder_log - null was returned from the specified logger and an error was detected.\r\n";
+			*this->stdout << "\tLog Level: " << log_level <<", Logger Type: " << logger_type << ", Message: " << message.c_str() << "\r\n";
 			
 			// I'm not sure what else to do here since I can't log the error.  I will print it 
 			// so that it shows up in the console, but I can't log it, and there is no way to 


### PR DESCRIPTION
Summary of changes:
* Allows swap of streams for stdout/stderr in gcode logger (to enforce non-formatted messages go to stderr to avoid script parsing complications)
* Adds simple CMake-built CLI in C++ (I don't know python very well)

The CMake organization is a little weird, might be worth a moving the location of the C++ code, leaving that up to the community/another PR though.

Motivation is to run on my beastly desktop in 5 seconds rather than my RPI 0 in 20 minutes for complex models.