### PR TITLE
Avoid comparison with NoneType

### DIFF
--- a/octoprint_arc_welder/__init__.py
+++ b/octoprint_arc_welder/__init__.py
@@ -195,7 +195,7 @@ class ArcWelderPlugin(
         # If we don't have a current version, look at the current settings file for the most recent version.
         if current is None:
             current_version = -1
-        if current < 2:
+        elif current < 2:
             logger.info("Migrating settings to version 2.")
             # change 'both' to 'always'
             if self._settings.get(["feature_settings", "file_processing"]) in ["both", "auto-only"]:


### PR DESCRIPTION
During octoprint startup I get a small stacktrace due to a comparison with None. Thus a simple fix should be replacing the fallthrough if checks with if else
```
octoprint - ERROR - Error while trying to migrate settings for plugin arc_welder, ignoring it
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/__init__.py", line 509, in init_settings_plugin_config_migration_and_cleanup
    implementation._identifier, implementation
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/__init__.py", line 493, in settings_plugin_config_migration_and_cleanup
    settings_migrator(settings_version, stored_version)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_arc_welder/__init__.py", line 194, in on_settings_migrate
    if current < 2:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

PS: Any suggestion to get a version number for my settings?^^ And of course thanks a lot for your dedication! I am using this plugin for a while now without problems :)